### PR TITLE
Added warning to indicate row range must be greaters the stack-min value

### DIFF
--- a/controllers/base.py
+++ b/controllers/base.py
@@ -152,7 +152,11 @@ class BaseController(Controller):
         elif args.max_stack is None:
             args.max_stack = 41
 
+        # RESTORED: Generate the list of stacks to sweep
+        stack_range = list(range(args.min_stack, args.max_stack))
+
         print(f"Target Input: {args.input}")
+        print(f"Stack sweep range: {args.min_stack} to {args.max_stack - 1}")
         print(f"Stack sweep range: {args.min_stack} to {args.max_stack - 1}")
 
         # 6. Execute Sweep Logic


### PR DESCRIPTION
Add a warning no prediction can be output if the start_row to end_row is less than the min_stack size.
The warning should tell the user the start to end row must be equal to or great than the min_stack size.
Inform the user start to end row values, start to end row difference and min_stack size values.
Indicate if start to end row and min_stack size values are defaults.

